### PR TITLE
ci: upgrade workflows to Node24-compatible actions and harden tag move auth

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -120,7 +120,7 @@ jobs:
           echo "update_latest_tag=$UPDATE_LATEST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create or update GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
           name: Release ${{ steps.meta.outputs.tag }}
@@ -144,6 +144,14 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           PUSH_REMOTE="origin"
+          if [[ "${UPDATE_STABLE_TAG}" == "true" || "${UPDATE_LATEST_TAG}" == "true" ]]; then
+            if [[ -z "${RELEASE_TAG_PUSH_TOKEN:-}" ]]; then
+              echo "Floating tag updates require RELEASE_TAG_PUSH_TOKEN secret (contents+workflows write)." >&2
+              echo "Disable update_stable_tag/update_latest_tag for this run or add the secret." >&2
+              exit 1
+            fi
+          fi
+
           if [[ -n "${RELEASE_TAG_PUSH_TOKEN:-}" ]]; then
             PUSH_REMOTE="https://x-access-token:${RELEASE_TAG_PUSH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           fi

--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,8 @@ CI also runs these checks automatically on every pull request via `.github/workf
 ### Automated Releases
 Release automation is defined in `.github/workflows/release.yml`.
 
+Workflows are pinned to Node 24-compatible action majors (`actions/checkout@v6`, `actions/setup-python@v6`, `github/codeql-action@v4`, and `softprops/action-gh-release@v3`).
+
 - Auto release: push a version tag matching `v*.*.*` (for example `v1.4.0`).
 - Manual release: run the `Release` workflow from GitHub Actions and provide `version`.
 


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions to Node 24-compatible major versions across workflows
  - `actions/checkout` -> `v6`
  - `actions/setup-python` -> `v6`
  - `github/codeql-action/*` -> `v4`
  - `softprops/action-gh-release` -> `v3`
- Harden release tag move step to fail fast with a clear message when floating tag updates are enabled but `RELEASE_TAG_PUSH_TOKEN` is missing.

## Why
- Fixes Node 20 deprecation warnings in Actions.
- Addresses release failures when moving floating tags (`latest`/`stable`) to commits that touch workflow files, where default `GITHUB_TOKEN` is insufficient.

## Validation
- Workflow files pass editor validation with no reported errors.

## Notes
- Configure repository secret `RELEASE_TAG_PUSH_TOKEN` with `contents:write` and `workflows:write` for floating tag updates.