### PR TITLE
feat: support prerelease floating tags in release workflow

### DIFF
--- a/.github/release-tags.env
+++ b/.github/release-tags.env
@@ -1,7 +1,9 @@
 # Defaults for push-triggered releases in .github/workflows/release.yml
 # Edit these values to customize floating release tags.
 
+PRERELEASE_TAG=pre-release
 STABLE_TAG=stable
 LATEST_TAG=latest
 UPDATE_STABLE_TAG=false
+UPDATE_PRERELEASE_TAG=true
 UPDATE_LATEST_TAG=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: false
         type: boolean
+      prerelease_tag:
+        description: "Floating prerelease tag name"
+        required: false
+        default: pre-release
+        type: string
       stable_tag:
         description: "Floating stable tag name"
         required: false
@@ -27,6 +32,11 @@ on:
         type: string
       update_stable_tag:
         description: "Move the stable floating tag to this release"
+        required: false
+        default: false
+        type: boolean
+      update_prerelease_tag:
+        description: "Move the prerelease floating tag to this release"
         required: false
         default: false
         type: boolean
@@ -84,9 +94,11 @@ jobs:
             TAG="v${NORMALIZED_VERSION}"
 
             PRERELEASE="${{ github.event.inputs.prerelease }}"
+            PRERELEASE_TAG="${{ github.event.inputs.prerelease_tag }}"
             STABLE_TAG="${{ github.event.inputs.stable_tag }}"
             LATEST_TAG="${{ github.event.inputs.latest_tag }}"
             UPDATE_STABLE_TAG="$(bool_or_default "${{ github.event.inputs.update_stable_tag }}" "true")"
+            UPDATE_PRERELEASE_TAG="$(bool_or_default "${{ github.event.inputs.update_prerelease_tag }}" "false")"
             UPDATE_LATEST_TAG="$(bool_or_default "${{ github.event.inputs.update_latest_tag }}" "true")"
           else
             TAG="${GITHUB_REF_NAME}"
@@ -96,9 +108,11 @@ jobs:
               PRERELEASE="false"
             fi
 
+            PRERELEASE_TAG="pre-release"
             STABLE_TAG="stable"
             LATEST_TAG="latest"
             UPDATE_STABLE_TAG="true"
+            UPDATE_PRERELEASE_TAG="true"
             UPDATE_LATEST_TAG="true"
 
             # Optional repository-level defaults for push-triggered releases.
@@ -107,17 +121,25 @@ jobs:
               source .github/release-tags.env
             fi
 
+            PRERELEASE_TAG="${PRERELEASE_TAG:-pre-release}"
             STABLE_TAG="${STABLE_TAG:-stable}"
             LATEST_TAG="${LATEST_TAG:-latest}"
             UPDATE_STABLE_TAG="$(bool_or_default "${UPDATE_STABLE_TAG:-true}" "true")"
+            UPDATE_PRERELEASE_TAG="$(bool_or_default "${UPDATE_PRERELEASE_TAG:-true}" "true")"
             UPDATE_LATEST_TAG="$(bool_or_default "${UPDATE_LATEST_TAG:-true}" "true")"
+
+            if [[ "$PRERELEASE" != "true" ]]; then
+              UPDATE_PRERELEASE_TAG="false"
+            fi
           fi
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "prerelease_tag=$PRERELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "stable_tag=$STABLE_TAG" >> "$GITHUB_OUTPUT"
           echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
           echo "update_stable_tag=$UPDATE_STABLE_TAG" >> "$GITHUB_OUTPUT"
+          echo "update_prerelease_tag=$UPDATE_PRERELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "update_latest_tag=$UPDATE_LATEST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create or update GitHub release
@@ -130,13 +152,15 @@ jobs:
           make_latest: ${{ steps.meta.outputs.prerelease == 'true' && 'false' || 'true' }}
 
       - name: Move floating tags
-        if: ${{ steps.meta.outputs.update_stable_tag == 'true' || steps.meta.outputs.update_latest_tag == 'true' }}
+        if: ${{ steps.meta.outputs.update_stable_tag == 'true' || steps.meta.outputs.update_prerelease_tag == 'true' || steps.meta.outputs.update_latest_tag == 'true' }}
         env:
           RELEASE_TAG_PUSH_TOKEN: ${{ secrets.RELEASE_TAG_PUSH_TOKEN }}
           TARGET_TAG: ${{ steps.meta.outputs.tag }}
+          PRERELEASE_TAG: ${{ steps.meta.outputs.prerelease_tag }}
           STABLE_TAG: ${{ steps.meta.outputs.stable_tag }}
           LATEST_TAG: ${{ steps.meta.outputs.latest_tag }}
           UPDATE_STABLE_TAG: ${{ steps.meta.outputs.update_stable_tag }}
+          UPDATE_PRERELEASE_TAG: ${{ steps.meta.outputs.update_prerelease_tag }}
           UPDATE_LATEST_TAG: ${{ steps.meta.outputs.update_latest_tag }}
         run: |
           set -euo pipefail
@@ -145,7 +169,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           PUSH_REMOTE="origin"
-          if [[ "${UPDATE_STABLE_TAG}" == "true" || "${UPDATE_LATEST_TAG}" == "true" ]]; then
+          if [[ "${UPDATE_STABLE_TAG}" == "true" || "${UPDATE_PRERELEASE_TAG}" == "true" || "${UPDATE_LATEST_TAG}" == "true" ]]; then
             if [[ -z "${RELEASE_TAG_PUSH_TOKEN:-}" ]]; then
               echo "Floating tag updates require RELEASE_TAG_PUSH_TOKEN secret (contents+workflows write)." >&2
               echo "Disable update_stable_tag/update_latest_tag for this run or add the secret." >&2
@@ -174,6 +198,10 @@ jobs:
 
           if [[ "${UPDATE_STABLE_TAG}" == "true" ]]; then
             move_tag "$STABLE_TAG"
+          fi
+
+          if [[ "${UPDATE_PRERELEASE_TAG}" == "true" ]]; then
+            move_tag "$PRERELEASE_TAG"
           fi
 
           if [[ "${UPDATE_LATEST_TAG}" == "true" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,10 @@ jobs:
             UPDATE_STABLE_TAG="$(bool_or_default "${{ github.event.inputs.update_stable_tag }}" "true")"
             UPDATE_PRERELEASE_TAG="$(bool_or_default "${{ github.event.inputs.update_prerelease_tag }}" "false")"
             UPDATE_LATEST_TAG="$(bool_or_default "${{ github.event.inputs.update_latest_tag }}" "true")"
+            
+            if [[ "$PRERELEASE" != "true" ]]; then
+              UPDATE_PRERELEASE_TAG="false"
+            fi
           else
             TAG="${GITHUB_REF_NAME}"
             if [[ "$TAG" == *-* ]]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,7 @@
 All notable changes to this project are documented in this file.
 
 ## Unreleased
+
 - docs: moved GitHub workflow and release automation setup details out of `readme.md` into `docs/repository-maintenance.md`.
 - docs: kept `readme.md` focused on program behavior, usage, and operation.
+- ci: release workflow now supports multiple floating tags on the same versioned release, including optional `pre-release`, `latest`, and `stable` tags.

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -33,10 +33,12 @@ Push-trigger defaults are configured in `.github/release-tags.env`:
 - `UPDATE_PRERELEASE_TAG`
 - `UPDATE_LATEST_TAG`
 
-One release can therefore point to multiple tags at once:
+One Git commit can therefore be referenced by multiple tags at once:
 
 - the immutable version tag (for example `v2.0.1`)
 - optional floating channel tags such as `pre-release`, `latest`, and `stable`
+
+The GitHub Release object itself still uses the version tag. The `pre-release` floating tag is only moved when the release is marked prerelease.
 
 ### Token Requirements For Tag Moves
 

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -3,36 +3,54 @@
 This document contains repository automation and GitHub workflow operations details that are intentionally excluded from the top-level README.
 
 ## CI Workflows
+
 - PR validation: `.github/workflows/pr-validate.yml`
 - Security scanning: `.github/workflows/codeql-analysis.yml`
 
 ## Release Workflow
+
 Release workflow file: `.github/workflows/release.yml`
 
 ### Trigger Modes
+
 - Automatic: push a tag matching `v*.*.*` (for example `v1.4.0`)
 - Manual: run workflow `Release` and provide `version` as either `1.2.3` or `v1.2.3`
 
 ### Floating Release Tags
+
 Floating tags are maintained for convenience:
+
+- `pre-release` (default tag name)
 - `stable` (default tag name)
 - `latest` (default tag name)
 
 Push-trigger defaults are configured in `.github/release-tags.env`:
+
+- `PRERELEASE_TAG`
 - `STABLE_TAG`
 - `LATEST_TAG`
 - `UPDATE_STABLE_TAG`
+- `UPDATE_PRERELEASE_TAG`
 - `UPDATE_LATEST_TAG`
 
+One release can therefore point to multiple tags at once:
+
+- the immutable version tag (for example `v2.0.1`)
+- optional floating channel tags such as `pre-release`, `latest`, and `stable`
+
 ### Token Requirements For Tag Moves
+
 If floating tag updates point to a commit that changes files under `.github/workflows/`, GitHub can reject updates made with the default Actions token.
 
 Set repository secret `RELEASE_TAG_PUSH_TOKEN` with:
+
 - `contents: write`
 - `workflows: write`
 
 ### Action Runtime Compatibility
+
 Workflows are pinned to Node 24-compatible major versions:
+
 - `actions/checkout@v6`
 - `actions/setup-python@v6`
 - `github/codeql-action@v4`


### PR DESCRIPTION
## Summary
- extend the release workflow to support an additional floating `pre-release` tag
- allow one release to carry the immutable version tag plus optional `pre-release`, `latest`, and `stable` floating tags
- add push-trigger defaults for prerelease tag behavior in `.github/release-tags.env`
- document the new release tagging behavior in repository maintenance docs and changelog

## Included changes
- add `prerelease_tag` and `update_prerelease_tag` workflow inputs
- update release metadata resolution for prerelease tag defaults and automatic behavior
- update floating tag move step to handle all selected floating tag channels
- prevent `pre-release` from moving on stable manual releases


## Validation
- workflow file validation passed with no reported errors
- documentation files were updated and validated
