### PR TITLE
feat: allow manual releases from a target commitish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,11 @@ on:
         description: "Release version (example: 1.2.3 or v1.2.3)"
         required: true
         type: string
+      target_commitish:
+        description: "Commit, branch, or tag to release (example: 66d3df8 or main)"
+        required: false
+        default: ""
+        type: string
       prerelease:
         description: "Mark this as a prerelease"
         required: false
@@ -92,6 +97,8 @@ jobs:
             }
 
             TAG="v${NORMALIZED_VERSION}"
+            TARGET_COMMITISH="${{ github.event.inputs.target_commitish }}"
+            TARGET_COMMITISH="${TARGET_COMMITISH:-${GITHUB_SHA}}"
 
             PRERELEASE="${{ github.event.inputs.prerelease }}"
             PRERELEASE_TAG="${{ github.event.inputs.prerelease_tag }}"
@@ -106,6 +113,7 @@ jobs:
             fi
           else
             TAG="${GITHUB_REF_NAME}"
+            TARGET_COMMITISH="${GITHUB_SHA}"
             if [[ "$TAG" == *-* ]]; then
               PRERELEASE="true"
             else
@@ -138,6 +146,7 @@ jobs:
           fi
 
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "target_commitish=$TARGET_COMMITISH" >> "$GITHUB_OUTPUT"
           echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "prerelease_tag=$PRERELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "stable_tag=$STABLE_TAG" >> "$GITHUB_OUTPUT"
@@ -150,6 +159,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
+          target_commitish: ${{ steps.meta.outputs.target_commitish }}
           name: Release ${{ steps.meta.outputs.tag }}
           generate_release_notes: true
           prerelease: ${{ steps.meta.outputs.prerelease }}
@@ -159,6 +169,7 @@ jobs:
         if: ${{ steps.meta.outputs.update_stable_tag == 'true' || steps.meta.outputs.update_prerelease_tag == 'true' || steps.meta.outputs.update_latest_tag == 'true' }}
         env:
           RELEASE_TAG_PUSH_TOKEN: ${{ secrets.RELEASE_TAG_PUSH_TOKEN }}
+          TARGET_COMMITISH: ${{ steps.meta.outputs.target_commitish }}
           TARGET_TAG: ${{ steps.meta.outputs.tag }}
           PRERELEASE_TAG: ${{ steps.meta.outputs.prerelease_tag }}
           STABLE_TAG: ${{ steps.meta.outputs.stable_tag }}
@@ -191,7 +202,7 @@ jobs:
           move_tag() {
             local floating_tag="$1"
             [[ -n "$floating_tag" ]] || return 0
-            git tag -fa "$floating_tag" "$TARGET_TAG" -m "Move $floating_tag -> $TARGET_TAG"
+            git tag -fa "$floating_tag" "$TARGET_COMMITISH" -m "Move $floating_tag -> $TARGET_TAG ($TARGET_COMMITISH)"
             if ! git push "$PUSH_REMOTE" "refs/tags/$floating_tag" --force; then
               echo "Failed to move floating tag '$floating_tag' to '$TARGET_TAG'." >&2
               echo "If this release points to commits that modify files under .github/workflows/," >&2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@ All notable changes to this project are documented in this file.
 
 - docs: moved GitHub workflow and release automation setup details out of `readme.md` into `docs/repository-maintenance.md`.
 - docs: kept `readme.md` focused on program behavior, usage, and operation.
+- ci: manual releases can now target a specific historic commit, branch, or tag via `target_commitish`.
 - ci: release workflow now supports multiple floating tags on the same versioned release, including optional `pre-release`, `latest`, and `stable` tags.

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -15,6 +15,7 @@ Release workflow file: `.github/workflows/release.yml`
 
 - Automatic: push a tag matching `v*.*.*` (for example `v1.4.0`)
 - Manual: run workflow `Release` and provide `version` as either `1.2.3` or `v1.2.3`
+- Optional for manual runs: set `target_commitish` to a specific commit, branch, or tag (for example `66d3df8`) to create the release from that historic ref
 
 ### Floating Release Tags
 


### PR DESCRIPTION
## Summary
- add `target_commitish` input to manual `Release` workflow runs
- allow creating a release from a specific commit, branch, or tag (for example `66d3df8`)
- ensure floating tags move to the resolved target commitish for manual runs
- document the new behavior in repository maintenance docs and changelog

## Included changes
- workflow input: `target_commitish`
- metadata output: `target_commitish`
- release creation now passes `target_commitish` to `softprops/action-gh-release`
- floating tag move step now tags the resolved target commitish

## Validation
- workflow lint/validation passed with no reported errors
- docs/changelog files updated and validated
