### PR TITLE
feat: use RELEASE_TAG_PUSH_TOKEN for GitHub release creation to preve…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,6 +158,7 @@ jobs:
       - name: Create or update GitHub release
         uses: softprops/action-gh-release@v3
         with:
+          token: ${{ secrets.RELEASE_TAG_PUSH_TOKEN != '' && secrets.RELEASE_TAG_PUSH_TOKEN || github.token }}
           tag_name: ${{ steps.meta.outputs.tag }}
           target_commitish: ${{ steps.meta.outputs.target_commitish }}
           name: Release ${{ steps.meta.outputs.tag }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ All notable changes to this project are documented in this file.
 - docs: kept `readme.md` focused on program behavior, usage, and operation.
 - ci: manual releases can now target a specific historic commit, branch, or tag via `target_commitish`.
 - ci: release workflow now supports multiple floating tags on the same versioned release, including optional `pre-release`, `latest`, and `stable` tags.
+- ci: release creation now uses `RELEASE_TAG_PUSH_TOKEN` (when present) to avoid 403 integration errors on protected historic commits.

--- a/docs/repository-maintenance.md
+++ b/docs/repository-maintenance.md
@@ -43,12 +43,14 @@ The GitHub Release object itself still uses the version tag. The `pre-release` f
 
 ### Token Requirements For Tag Moves
 
-If floating tag updates point to a commit that changes files under `.github/workflows/`, GitHub can reject updates made with the default Actions token.
+If release creation or floating tag updates point to a commit that changes files under `.github/workflows/`, GitHub can reject updates made with the default Actions token.
 
 Set repository secret `RELEASE_TAG_PUSH_TOKEN` with:
 
 - `contents: write`
 - `workflows: write`
+
+This token is used for both creating/updating the GitHub Release and moving floating tags.
 
 ### Action Runtime Compatibility
 


### PR DESCRIPTION
…nt 403 errors on protected commits